### PR TITLE
Forgot and reset password improvements

### DIFF
--- a/src/config/environment/index.js
+++ b/src/config/environment/index.js
@@ -9,7 +9,7 @@ let base = {
   port: process.env.PORT || 3001,
   isDev: env === 'development',
   isTest: env === 'test',
-  webUrl: 'http://localhost:3000',
+  webUrl: 'http://localhost:3002',
   jwtSecret: 'jwt_secret',
 };
 

--- a/src/resources/account/account.controller.js
+++ b/src/resources/account/account.controller.js
@@ -87,7 +87,7 @@ exports.signin = async (ctx, next) => {
 /**
 * Send forgot password email with a unique link to set new password
 * If user is found by email - sends forgot password email and update
-* `forgotPasswordToken` field. If user not found, still return 200 response
+* `forgotPasswordToken` field. If user not found, returns validator's error
 */
 exports.forgotPassword = async (ctx, next) => {
   const result = await validators.forgotPassword.validate(ctx);
@@ -96,15 +96,13 @@ exports.forgotPassword = async (ctx, next) => {
   const { value: data } = result;
   const user = await userService.findOne({ email: data.email });
 
-  if (user) {
-    let { resetPasswordToken } = user;
-    if (!resetPasswordToken) {
-      resetPasswordToken = await securityUtil.generateSecureToken();
-      await userService.updateResetPasswordToken(user._id, resetPasswordToken);
-    }
-
-    await emailService.sendForgotPassword(user, resetPasswordToken);
+  let { resetPasswordToken } = user;
+  if (!resetPasswordToken) {
+    resetPasswordToken = await securityUtil.generateSecureToken();
+    await userService.updateResetPasswordToken(user._id, resetPasswordToken);
   }
+
+  await emailService.sendForgotPassword(user, resetPasswordToken);
 
   ctx.body = {};
 };

--- a/src/resources/account/account.test.js
+++ b/src/resources/account/account.test.js
@@ -152,9 +152,23 @@ module.exports = (request) => {
     it('should successfully send forgot password link', (done) => {
       request.post('/account/forgotPassword')
         .send({
-          user: newUserData.email,
+          email: newUserData.email,
         })
         .expect(200)
+        .end(done);
+    });
+
+    it('should return an error forgot password email is not registered', (done) => {
+      const email = 'not@registered.user';
+      request.post('/account/forgotPassword')
+        .send({
+          email,
+        })
+        .expect(400)
+        .expect(({ body }) => {
+          const { errors } = body;
+          errors[0].email.should.be.equal(`Couldn't find account associated with ${email}. Please try again`);
+        })
         .end(done);
     });
 
@@ -167,7 +181,7 @@ module.exports = (request) => {
         .expect(400)
         .expect(({ body }) => {
           const { errors } = body;
-          errors[0].token.should.be.equal('Token is invalid');
+          errors[0].token.should.be.equal('Password reset link has expired or invalid');
         })
         .end(done);
     });

--- a/src/resources/account/validators/forgotPassword.validator.js
+++ b/src/resources/account/validators/forgotPassword.validator.js
@@ -1,5 +1,6 @@
 const Joi = require('joi');
 const baseValidator = require('resources/base.validator');
+const userService = require('resources/user/user.service');
 
 const schema = {
   email: Joi.string()
@@ -14,4 +15,13 @@ const schema = {
     }),
 };
 
-exports.validate = ctx => baseValidator(ctx, schema, data => data);
+exports.validate = ctx => baseValidator(ctx, schema, async (data) => {
+  const userExists = await userService.exists({ email: data.email });
+
+  if (!userExists) {
+    ctx.errors.push({ email: `Couldn't find account associated with ${data.email}. Please try again` });
+    return false;
+  }
+
+  return data;
+});

--- a/src/resources/account/validators/resetPassword.validator.js
+++ b/src/resources/account/validators/resetPassword.validator.js
@@ -23,7 +23,7 @@ const schema = {
 exports.validate = ctx => baseValidator(ctx, schema, async (data) => {
   const user = await userService.findOne({ resetPasswordToken: data.token });
   if (!user) {
-    ctx.errors.push({ token: 'Token is invalid' });
+    ctx.errors.push({ token: 'Password reset link has expired or invalid' });
     return false;
   }
 


### PR DESCRIPTION
- Change webUrl port to 3002 to match ship configuration (landing :3000, api :3001, web :3002)

- Changed validator to return an error if trying to reset a link for non-registered email instead of just ignoring it (like github, gmail, airbnb and other websites do)

- Minor wording improvements